### PR TITLE
Add setup bootstrap and TamaOS skeleton

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,13 @@
+# Example environment variables for TamaOS
+# Copy this file to .env and adjust values for your environment.
+
+# How many real seconds make up one full century of Tama life.
+CENTURY_REAL_SEC=3153600000
+
+# Paths for runtime storage.
+VFS_PATH=./vfs
+LOG_PATH=./logs
+
+# Optional settings
+TAMAOS_NAME=TamaOS
+LOG_LEVEL=INFO

--- a/.gitignore
+++ b/.gitignore
@@ -1,207 +1,41 @@
-# Byte-compiled / optimized / DLL files
+# Runtime artifacts
+logs/
+vfs/
+
+# Python caches
 __pycache__/
-*.py[codz]
+*.py[cod]
 *$py.class
 
-# C extensions
-*.so
-
-# Distribution / packaging
-.Python
-build/
-develop-eggs/
-dist/
-downloads/
-eggs/
-.eggs/
-lib/
-lib64/
-parts/
-sdist/
-var/
-wheels/
-share/python-wheels/
-*.egg-info/
-.installed.cfg
-*.egg
-MANIFEST
-
-# PyInstaller
-#  Usually these files are written by a python script from a template
-#  before PyInstaller builds the exe, so as to inject date/other infos into it.
-*.manifest
-*.spec
-
-# Installer logs
-pip-log.txt
-pip-delete-this-directory.txt
-
-# Unit test / coverage reports
-htmlcov/
-.tox/
-.nox/
-.coverage
-.coverage.*
-.cache
-nosetests.xml
-coverage.xml
-*.cover
-*.py.cover
-.hypothesis/
-.pytest_cache/
-cover/
-
-# Translations
-*.mo
-*.pot
-
-# Django stuff:
-*.log
-local_settings.py
-db.sqlite3
-db.sqlite3-journal
-
-# Flask stuff:
-instance/
-.webassets-cache
-
-# Scrapy stuff:
-.scrapy
-
-# Sphinx documentation
-docs/_build/
-
-# PyBuilder
-.pybuilder/
-target/
-
-# Jupyter Notebook
-.ipynb_checkpoints
-
-# IPython
-profile_default/
-ipython_config.py
-
-# pyenv
-#   For a library or package, you might want to ignore these files since the code is
-#   intended to run in multiple environments; otherwise, check them in:
-# .python-version
-
-# pipenv
-#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
-#   However, in case of collaboration, if having platform-specific dependencies or dependencies
-#   having no cross-platform support, pipenv may install dependencies that don't work, or not
-#   install all needed dependencies.
-#Pipfile.lock
-
-# UV
-#   Similar to Pipfile.lock, it is generally recommended to include uv.lock in version control.
-#   This is especially recommended for binary packages to ensure reproducibility, and is more
-#   commonly ignored for libraries.
-#uv.lock
-
-# poetry
-#   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
-#   This is especially recommended for binary packages to ensure reproducibility, and is more
-#   commonly ignored for libraries.
-#   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
-#poetry.lock
-#poetry.toml
-
-# pdm
-#   Similar to Pipfile.lock, it is generally recommended to include pdm.lock in version control.
-#   pdm recommends including project-wide configuration in pdm.toml, but excluding .pdm-python.
-#   https://pdm-project.org/en/latest/usage/project/#working-with-version-control
-#pdm.lock
-#pdm.toml
-.pdm-python
-.pdm-build/
-
-# pixi
-#   Similar to Pipfile.lock, it is generally recommended to include pixi.lock in version control.
-#pixi.lock
-#   Pixi creates a virtual environment in the .pixi directory, just like venv module creates one
-#   in the .venv directory. It is recommended not to include this directory in version control.
-.pixi
-
-# PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
-__pypackages__/
-
-# Celery stuff
-celerybeat-schedule
-celerybeat.pid
-
-# SageMath parsed files
-*.sage.py
-
-# Environments
-.env
-.envrc
-.venv
+# Virtual environments
+.venv/
 env/
 venv/
 ENV/
-env.bak/
-venv.bak/
 
-# Spyder project settings
-.spyderproject
-.spyproject
+# Environment files
+.env
+.env.*
+!.env.example
 
-# Rope project settings
-.ropeproject
+# Packaging
+build/
+dist/
+*.egg-info/
+.eggs/
 
-# mkdocs documentation
-/site
-
-# mypy
+# Tooling caches
+.pytest_cache/
 .mypy_cache/
 .dmypy.json
-dmypy.json
-
-# Pyre type checker
 .pyre/
-
-# pytype static type analyzer
 .pytype/
-
-# Cython debug symbols
-cython_debug/
-
-# PyCharm
-#  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
-#  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
-#  and can be added to the global gitignore or merged into this file.  For a more nuclear
-#  option (not recommended) you can uncomment the following to ignore the entire idea folder.
-#.idea/
-
-# Abstra
-# Abstra is an AI-powered process automation framework.
-# Ignore directories containing user credentials, local state, and settings.
-# Learn more at https://abstra.io/docs
-.abstra/
-
-# Visual Studio Code
-#  Visual Studio Code specific template is maintained in a separate VisualStudioCode.gitignore 
-#  that can be found at https://github.com/github/gitignore/blob/main/Global/VisualStudioCode.gitignore
-#  and can be added to the global gitignore or merged into this file. However, if you prefer, 
-#  you could uncomment the following to ignore the entire vscode folder
-# .vscode/
-
-# Ruff stuff:
 .ruff_cache/
 
-# PyPI configuration file
-.pypirc
+# Editors
+.vscode/
+.idea/
 
-# Cursor
-#  Cursor is an AI-powered code editor. `.cursorignore` specifies files/directories to
-#  exclude from AI features like autocomplete and code analysis. Recommended for sensitive data
-#  refer to https://docs.cursor.com/context/ignore-files
-.cursorignore
-.cursorindexingignore
-
-# Marimo
-marimo/_static/
-marimo/_lsp/
-__marimo__/
+# OS junk
+.DS_Store
+Thumbs.db

--- a/README.md
+++ b/README.md
@@ -1,96 +1,47 @@
-# BSS-TamagotchiCipherum-LatticeTamaOS
-A Blue $nake Studio experimental Tamagotchi-like agent — runs inside its own OS with lattice learning, century life, and symbolic skins.”
-Here’s a **first draft `README.md`** you can drop right into the repo. It’s written to look sharp, give context, and reflect your **Blue \$nake Studio (B\$S)** style while staying practical for GitHub.
+# TamaOS Bootstrap
 
----
+TamaOS is a sandboxed Tamagotchi experiment from Blue $nake Studio. This repo contains a
+minimal Python skeleton and a setup script that bootstraps both Codex containers and local
+development machines.
 
-````markdown
-# 🐍 TamaOS — A Blue $nake Studio Experiment
-
-**TamaOS** is a Tamagotchi-like **agent** that lives inside its own operating system.  
-It isn’t a game that runs on your computer — it’s a *universe in miniature* where the creature evolves, learns, and survives on the rules of its environment.
-
----
-
-## ✨ Features
-
-- **Self-Contained OS**  
-  Runs as a sandbox kernel with its own message bus, devices, and virtual filesystem.
-
-- **Lattice Memory**  
-  A geometric neural sheet where palindromes (Mirror) and shards (Entropy) shape the agent’s intelligence.
-
-- **Century Life System**  
-  The creature has a *100-year virtual lifespan* — stages of growth unlock in proportion to real time.  
-  No grinding, no idling exploits.
-
-- **Symbolic Skins (B$S Style)**  
-  ASCII forms that shift between **Mirror ◈**, **Shard ><**, and **Flux ⟡** dominance.  
-  Each form has aura and mood overlays (Sleep, Hunger, Wild, etc).
-
-- **Net Learning Device**  
-  You are the Internet. Add snippets, tags, or concepts and the agent integrates them as its knowledge stream.
-
----
-
-## 🌌 Universe Rules
-
-1. Three forging stars define the cosmos: **Mirror**, **Shard**, **Flux**.  
-2. Position in the starfield sets environmental intensity (`Ψ`).  
-3. Every input ripples through **all stats** — nothing is isolated.  
-4. Growth is **time-gated** by the Century Life device.  
-5. Observation shows the current skin, aura, and stage.
-
----
-
-## 🚀 Getting Started
-
-Clone the repository:
-```bash
-git clone https://github.com/Blackcockatoo/TamaOS.git
-cd TamaOS
-````
-
-Run the kernel (Python 3.10+ recommended):
+## Quick start
 
 ```bash
-python tamaos.py
+# Run once after cloning
+bash setup.sh
+
+# Activate the virtual environment
+source .venv/bin/activate
+
+# Launch the TamaOS shell
+python -m tamaos.main
 ```
 
-From inside the REPL you can:
+The shell prints a banner showing where the virtual file system and logs live. Type
+`status` inside the REPL to inspect the loaded configuration, or `exit` to quit.
 
-```text
-post tablet.feed {"number":"13031"}   # feed palindrome → Mirror stability
-post tablet.teach {"token":"A"}       # teach basic symbol → Letters concept
-post net.add {"text":"Symmetry teaches order","tags":["mirror"]}
-tick 5                                # advance time by 5 ticks
-observe                               # view current ASCII form
-```
+## Environment variables
 
----
+Configuration is provided via environment variables or a local `.env` file. Default
+values keep the project self-contained when nothing is specified.
 
-## 🧬 Roadmap
+| Variable            | Description                                                    | Default         |
+| ------------------- | -------------------------------------------------------------- | --------------- |
+| `CENTURY_REAL_SEC`  | Real-world seconds that represent the creature's 100-year life | `3153600000`    |
+| `VFS_PATH`          | Directory used as the virtual filesystem root                  | `./vfs`         |
+| `LOG_PATH`          | Directory used for runtime logs                                | `./logs`        |
+| `TAMAOS_NAME`       | Display name for the boot banner                               | `TamaOS`        |
+| `LOG_LEVEL`         | Logging verbosity hint for future services                     | `INFO`          |
 
-* [ ] ASCII starfield visualizer (`universe.map`)
-* [ ] Room/biome exploration (Mini Tamaverse)
-* [ ] Richer learning (concept graph → codon mutation)
-* [ ] Export/import life snapshots
-* [ ] Web UI with React sandbox
+Create a `.env` file based on `.env.example` to override these locally without exporting
+them in your shell.
 
----
+## What `setup.sh` does
 
-## 📜 License
+1. Loads environment overrides from `.env` (if present) without overriding existing shell vars.
+2. Ensures Python 3 and `venv` are available, then creates `.venv/`.
+3. Installs pinned dependencies from `requirements.txt`.
+4. Creates runtime directories for the virtual filesystem and logs.
+5. Runs a smoke test that imports `tamaos.config` and prints the resolved configuration.
 
-Released under the [MIT License](LICENSE).
-Built as part of Blue \$nake Studio’s mythic-engineering experiments.
-
----
-
-**Blue \$nake Studio** 🌀 *Infinite complexity in finite simplicity.*
-
-```
-
----
-
-Would you like me to also generate the **badges and banner-style ASCII logo** (so the README pops visually right at the top), or keep it clean and minimal for the first commit?
-```
+After the script completes, the repository is ready for you to extend the agent kernel.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+python-dotenv==1.0.1

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+VENV_DIR="$ROOT_DIR/.venv"
+PYTHON_BIN="${PYTHON_BIN:-python3}"
+
+bold="\033[1m"
+normal="\033[0m"
+log() {
+  printf "%b[setup]%b %s\n" "$bold" "$normal" "$1"
+}
+
+log "Project root: $ROOT_DIR"
+
+if [ -f "$ROOT_DIR/.env" ]; then
+  log "Loading .env for local overrides"
+  # Export variables from .env without clobbering existing ones
+  while IFS='=' read -r key value; do
+    # Skip comments and empty lines
+    if [[ -z "$key" ]] || [[ "$key" =~ ^[[:space:]]*# ]]; then
+      continue
+    fi
+
+    key="${key##[[:space:]]*}"
+    key="${key%%[[:space:]]*}"
+    if [[ ! "$key" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]]; then
+      continue
+    fi
+
+    value="${value%%$'\r'}"
+    value="${value%%#*}"
+    value="${value%%|*}"
+    value="${value##[[:space:]]*}"
+    value="${value%%[[:space:]]*}"
+    value="${value%\"}"
+    value="${value#\"}"
+    value="${value%\'}"
+    value="${value#\'}"
+
+    if [ -z "${!key:-}" ]; then
+      export "$key=$value"
+    fi
+  done < "$ROOT_DIR/.env"
+else
+  log "No .env found. Using environment / defaults."
+fi
+
+if ! command -v "$PYTHON_BIN" >/dev/null 2>&1; then
+  printf 'Error: %s is required but was not found on PATH.\n' "$PYTHON_BIN" >&2
+  exit 1
+fi
+
+log "Using Python interpreter: $(command -v "$PYTHON_BIN")"
+
+if [ ! -d "$VENV_DIR" ]; then
+  log "Creating virtual environment"
+  "$PYTHON_BIN" -m venv "$VENV_DIR"
+else
+  log "Virtual environment already exists"
+fi
+
+PIP_BIN="$VENV_DIR/bin/pip"
+PY_BIN="$VENV_DIR/bin/python"
+
+log "Upgrading pip"
+"$PY_BIN" -m pip install --upgrade pip >/dev/null
+
+log "Installing Python requirements"
+"$PIP_BIN" install --requirement "$ROOT_DIR/requirements.txt"
+
+log "Ensuring runtime directories and validating configuration"
+"$PY_BIN" <<'PY'
+from tamaos.config import settings
+
+settings.ensure_runtime_paths()
+print(settings.summary())
+PY
+
+log "Running smoke test"
+"$PY_BIN" <<'PY'
+from tamaos.config import settings
+from pathlib import Path
+
+missing = [str(path) for path in settings.runtime_paths if not Path(path).exists()]
+if missing:
+    raise SystemExit(f"Runtime paths missing: {', '.join(missing)}")
+
+print("Smoke test passed: configuration and runtime paths are ready.")
+PY
+
+log "Setup complete. Next steps:"
+echo "  source \"$VENV_DIR/bin/activate\""
+echo "  python -m tamaos.main"

--- a/tamaos/__init__.py
+++ b/tamaos/__init__.py
@@ -1,0 +1,4 @@
+"""TamaOS package bootstrap."""
+from .config import settings
+
+__all__ = ["settings"]

--- a/tamaos/config.py
+++ b/tamaos/config.py
@@ -1,0 +1,92 @@
+"""Configuration loader for TamaOS."""
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable
+
+from dotenv import load_dotenv
+
+# Root of the repository (the directory containing this file is tamaos/)
+ROOT_DIR = Path(__file__).resolve().parents[1]
+ENV_FILE = ROOT_DIR / ".env"
+
+# Load .env variables if present. Values injected via the environment take precedence.
+load_dotenv(dotenv_path=ENV_FILE, override=False)
+
+
+def _get_int(name: str, default: int) -> int:
+    value = os.getenv(name)
+    if value is None or value.strip() == "":
+        return default
+    try:
+        return int(float(value))
+    except (TypeError, ValueError):
+        return default
+
+
+def _get_path(name: str, default: Path) -> Path:
+    value = os.getenv(name)
+    if value is None or value.strip() == "":
+        return default
+    expanded = Path(value).expanduser()
+    try:
+        return expanded.resolve()
+    except FileNotFoundError:
+        return expanded
+
+
+def _get_str(name: str, default: str) -> str:
+    value = os.getenv(name)
+    return value if value not in (None, "") else default
+
+
+@dataclass(frozen=True)
+class Settings:
+    """Resolved configuration values for TamaOS."""
+
+    root_dir: Path
+    env_file: Path
+    century_real_seconds: int
+    vfs_path: Path
+    log_path: Path
+    tamaos_name: str
+    log_level: str
+
+    def ensure_runtime_paths(self) -> None:
+        """Create runtime directories if they do not exist."""
+
+        for path in self.runtime_paths:
+            path.mkdir(parents=True, exist_ok=True)
+
+    @property
+    def runtime_paths(self) -> Iterable[Path]:
+        return (self.vfs_path, self.log_path)
+
+    def summary(self) -> str:
+        return (
+            f"Settings:\n"
+            f"  root_dir: {self.root_dir}\n"
+            f"  env_file: {self.env_file}\n"
+            f"  century_real_seconds: {self.century_real_seconds}\n"
+            f"  vfs_path: {self.vfs_path}\n"
+            f"  log_path: {self.log_path}\n"
+            f"  tamaos_name: {self.tamaos_name}\n"
+            f"  log_level: {self.log_level}"
+        )
+
+
+_century_default = 100 * 365 * 24 * 60 * 60
+_default_vfs = (ROOT_DIR / "vfs").resolve()
+_default_logs = (ROOT_DIR / "logs").resolve()
+
+settings = Settings(
+    root_dir=ROOT_DIR,
+    env_file=ENV_FILE,
+    century_real_seconds=_get_int("CENTURY_REAL_SEC", _century_default),
+    vfs_path=_get_path("VFS_PATH", _default_vfs),
+    log_path=_get_path("LOG_PATH", _default_logs),
+    tamaos_name=_get_str("TAMAOS_NAME", "TamaOS"),
+    log_level=_get_str("LOG_LEVEL", "INFO"),
+)

--- a/tamaos/main.py
+++ b/tamaos/main.py
@@ -1,0 +1,61 @@
+"""Minimal entry point for TamaOS."""
+from __future__ import annotations
+
+from textwrap import dedent
+
+from .config import settings
+
+
+def _format_century(seconds: int) -> str:
+    years = seconds / (365 * 24 * 60 * 60)
+    return f"{seconds:,} seconds (~{years:.2f} years)"
+
+
+def _banner() -> str:
+    return dedent(
+        f"""
+        ===============================
+        {settings.tamaos_name} bootstrap
+        ===============================
+        Century duration : {_format_century(settings.century_real_seconds)}
+        Virtual FS path  : {settings.vfs_path}
+        Logs path        : {settings.log_path}
+        Log level        : {settings.log_level}
+        -------------------------------
+        Type 'status' for settings, 'exit' to quit.
+        """
+    ).strip()
+
+
+def repl() -> None:
+    """A stub REPL for future TamaOS commands."""
+
+    print(_banner())
+    while True:
+        try:
+            command = input("tamaos> ").strip()
+        except (EOFError, KeyboardInterrupt):
+            print()
+            break
+
+        if not command:
+            continue
+        lowered = command.lower()
+        if lowered in {"exit", "quit"}:
+            break
+        if lowered == "status":
+            print(settings.summary())
+            continue
+        print(f"Unknown command: {command}")
+
+    print("Exiting TamaOS shell. Goodbye!")
+
+
+def main() -> int:
+    settings.ensure_runtime_paths()
+    repl()
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entrypoint
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add a portable `setup.sh` script that provisions a virtualenv, installs requirements, loads `.env`, and runs a smoke test
- scaffold the `tamaos` package with configuration loading and a minimal REPL entry point
- document the workflow, provide sample environment variables, tighten the gitignore, and pin python-dotenv

## Testing
- bash setup.sh
- .venv/bin/python -m tamaos.main

------
https://chatgpt.com/codex/tasks/task_e_68d1b1640d90832f8aa21e726fc63de3