### PR TITLE
Add stylized UI skins and animations to TamaOS shell

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ values keep the project self-contained when nothing is specified.
 | `LOG_PATH`          | Directory used for runtime logs                                | `./logs`        |
 | `TAMAOS_NAME`       | Display name for the boot banner                               | `TamaOS`        |
 | `LOG_LEVEL`         | Logging verbosity hint for future services                     | `INFO`          |
+| `TAMAOS_UI_SKIN`    | Default UI skin rendered around the shell banner                | `classic`       |
+| `TAMAOS_ANIMATE_UI` | Whether to play banner animations on startup (`true`/`false`)   | `true`          |
 
 Create a `.env` file based on `.env.example` to override these locally without exporting
 them in your shell.
@@ -45,3 +47,19 @@ them in your shell.
 5. Runs a smoke test that imports `tamaos.config` and prints the resolved configuration.
 
 After the script completes, the repository is ready for you to extend the agent kernel.
+
+## Styling the shell
+
+The stub REPL now supports playful banner skins and boot animations. Use the `skin`
+command inside the shell to explore the options:
+
+```text
+skin list           # Show all available skins and their descriptions
+skin use synthwave  # Switch to the "synthwave" skin and redraw the banner
+skin show           # Re-render the banner with the currently selected skin
+skin animate off    # Disable or re-enable the introductory animation
+```
+
+Set the default skin and animation behaviour with the `TAMAOS_UI_SKIN` and
+`TAMAOS_ANIMATE_UI` environment variables (see the table above) if you want the
+shell to boot directly into a specific vibe.

--- a/tamaos/config.py
+++ b/tamaos/config.py
@@ -42,6 +42,16 @@ def _get_str(name: str, default: str) -> str:
     return value if value not in (None, "") else default
 
 
+def _get_bool(name: str, default: bool) -> bool:
+    value = os.getenv(name)
+    if value is None:
+        return default
+    normalized = value.strip().lower()
+    if normalized == "":
+        return default
+    return normalized in {"1", "true", "yes", "on"}
+
+
 @dataclass(frozen=True)
 class Settings:
     """Resolved configuration values for TamaOS."""
@@ -53,6 +63,8 @@ class Settings:
     log_path: Path
     tamaos_name: str
     log_level: str
+    ui_skin: str
+    animate_ui: bool
 
     def ensure_runtime_paths(self) -> None:
         """Create runtime directories if they do not exist."""
@@ -73,7 +85,9 @@ class Settings:
             f"  vfs_path: {self.vfs_path}\n"
             f"  log_path: {self.log_path}\n"
             f"  tamaos_name: {self.tamaos_name}\n"
-            f"  log_level: {self.log_level}"
+            f"  log_level: {self.log_level}\n"
+            f"  ui_skin: {self.ui_skin}\n"
+            f"  animate_ui: {self.animate_ui}"
         )
 
 
@@ -89,4 +103,6 @@ settings = Settings(
     log_path=_get_path("LOG_PATH", _default_logs),
     tamaos_name=_get_str("TAMAOS_NAME", "TamaOS"),
     log_level=_get_str("LOG_LEVEL", "INFO"),
+    ui_skin=_get_str("TAMAOS_UI_SKIN", "classic").lower(),
+    animate_ui=_get_bool("TAMAOS_ANIMATE_UI", True),
 )

--- a/tamaos/main.py
+++ b/tamaos/main.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 
 from textwrap import dedent
 
+from .skins import SkinManager
+
 from .config import settings
 
 
@@ -11,7 +13,13 @@ def _format_century(seconds: int) -> str:
     return f"{seconds:,} seconds (~{years:.2f} years)"
 
 
-def _banner() -> str:
+skin_manager = SkinManager(
+    default_skin=settings.ui_skin,
+    animate=settings.animate_ui,
+)
+
+
+def _banner_content() -> str:
     return dedent(
         f"""
         ===============================
@@ -21,16 +29,69 @@ def _banner() -> str:
         Virtual FS path  : {settings.vfs_path}
         Logs path        : {settings.log_path}
         Log level        : {settings.log_level}
+        Active skin      : {skin_manager.current_name}
         -------------------------------
-        Type 'status' for settings, 'exit' to quit.
+        Type 'status' for settings, 'skin help' for styling, 'exit' to quit.
         """
     ).strip()
+
+
+def _print_banner() -> None:
+    print(skin_manager.render_banner(_banner_content()))
+
+
+def _handle_skin_command(parts: list[str]) -> None:
+    if not parts or parts[0].lower() in {"help", "?"}:
+        print("Usage: skin list | skin use <name> | skin show | skin animate <on|off>")
+        return
+
+    action = parts[0].lower()
+    if action == "list":
+        for skin in skin_manager.list_skins():
+            marker = "*" if skin.name == skin_manager.current_name else "-"
+            print(f"{marker} {skin.name:<10} : {skin.display_name} — {skin.description}")
+        return
+
+    if action in {"use", "set"}:
+        if len(parts) < 2:
+            print("Usage: skin use <name>")
+            return
+        target = parts[1]
+        if skin_manager.set_skin(target):
+            print(f"Skin set to '{skin_manager.current_name}'.")
+            _print_banner()
+        else:
+            available = ", ".join(sorted(s.name for s in skin_manager.list_skins()))
+            print(f"Unknown skin '{target}'. Available skins: {available}")
+        return
+
+    if action == "show":
+        _print_banner()
+        return
+
+    if action == "animate":
+        if len(parts) < 2:
+            status = "on" if skin_manager.animation_enabled() else "off"
+            print(f"Animation is currently {status}. Use 'skin animate on' or 'skin animate off'.")
+            return
+        toggle = parts[1].lower()
+        if toggle not in {"on", "off"}:
+            print("Usage: skin animate <on|off>")
+            return
+        skin_manager.set_animation(toggle == "on")
+        print(f"Animation {'enabled' if toggle == 'on' else 'disabled'}.")
+        return
+
+    print("Usage: skin list | skin use <name> | skin show | skin animate <on|off>")
 
 
 def repl() -> None:
     """A stub REPL for future TamaOS commands."""
 
-    print(_banner())
+    if skin_manager.animation_enabled():
+        skin_manager.play_intro(_banner_content())
+    else:
+        _print_banner()
     while True:
         try:
             command = input("tamaos> ").strip()
@@ -40,11 +101,15 @@ def repl() -> None:
 
         if not command:
             continue
-        lowered = command.lower()
+        parts = command.split()
+        lowered = parts[0].lower()
         if lowered in {"exit", "quit"}:
             break
         if lowered == "status":
             print(settings.summary())
+            continue
+        if lowered == "skin":
+            _handle_skin_command(parts[1:])
             continue
         print(f"Unknown command: {command}")
 

--- a/tamaos/skins.py
+++ b/tamaos/skins.py
@@ -1,0 +1,182 @@
+"""UI skins and playful animations for the TamaOS shell."""
+from __future__ import annotations
+
+import sys
+import time
+from dataclasses import dataclass
+from typing import Dict, Iterable, Sequence
+
+DEFAULT_SKIN_NAME = "classic"
+
+
+@dataclass(frozen=True)
+class Skin:
+    """Represents a banner skin with optional title art and animation frames."""
+
+    name: str
+    display_name: str
+    description: str
+    top_left: str
+    top_right: str
+    bottom_left: str
+    bottom_right: str
+    horizontal: str
+    vertical: str
+    padding: int = 2
+    title_lines: Sequence[str] = ()
+    animation_frames: Sequence[str] = ()
+
+    def render(self, content: str) -> str:
+        """Render the provided content inside the skin's decorative frame."""
+
+        lines = content.splitlines() or [""]
+        width = max(len(line) for line in lines)
+        inner_width = width + self.padding * 2
+        horizontal_line = self.horizontal * inner_width
+        top = f"{self.top_left}{horizontal_line}{self.top_right}"
+        bottom = f"{self.bottom_left}{horizontal_line}{self.bottom_right}"
+
+        padded_lines = [
+            f"{self.vertical}{' ' * self.padding}{line.ljust(width)}{' ' * self.padding}{self.vertical}"
+            for line in lines
+        ]
+
+        banner_lines = []
+        if self.title_lines:
+            context = {
+                "bar": horizontal_line,
+                "name": self.display_name,
+                "width": inner_width,
+            }
+            banner_lines.extend(line.format(**context) for line in self.title_lines)
+
+        banner_lines.append(top)
+        banner_lines.extend(padded_lines)
+        banner_lines.append(bottom)
+        return "\n".join(banner_lines)
+
+    def animate(self, stream, repeat: int = 2, delay: float = 0.12) -> None:
+        """Play the skin's animation frames on the provided stream."""
+
+        if not self.animation_frames:
+            return
+        frames = list(self.animation_frames)
+        width = max(len(frame) for frame in frames)
+        for _ in range(repeat):
+            for frame in frames:
+                stream.write("\r" + frame.ljust(width))
+                stream.flush()
+                time.sleep(delay)
+        stream.write("\r" + " " * width + "\r")
+        stream.flush()
+
+
+class SkinManager:
+    """Utility for working with the available UI skins."""
+
+    def __init__(self, default_skin: str = DEFAULT_SKIN_NAME, animate: bool = True, stream=None) -> None:
+        self._skins: Dict[str, Skin] = {skin.name: skin for skin in _BUILTIN_SKINS}
+        normalized = default_skin.lower()
+        self._current_name = normalized if normalized in self._skins else DEFAULT_SKIN_NAME
+        self._animate = animate
+        self._stream = stream if stream is not None else sys.stdout
+
+    @property
+    def current_skin(self) -> Skin:
+        return self._skins[self._current_name]
+
+    @property
+    def current_name(self) -> str:
+        return self._current_name
+
+    def list_skins(self) -> Iterable[Skin]:
+        return self._skins.values()
+
+    def set_skin(self, name: str) -> bool:
+        key = name.lower()
+        if key in self._skins:
+            self._current_name = key
+            return True
+        return False
+
+    def render_banner(self, content: str) -> str:
+        return self.current_skin.render(content)
+
+    def play_intro(self, content: str) -> None:
+        if self._should_animate():
+            self.current_skin.animate(self._stream)
+        print(self.render_banner(content), file=self._stream)
+
+    def animation_enabled(self) -> bool:
+        return self._animate
+
+    def set_animation(self, enabled: bool) -> None:
+        self._animate = enabled
+
+    def _should_animate(self) -> bool:
+        if not self._animate:
+            return False
+        stream = self._stream
+        is_tty = getattr(stream, "isatty", lambda: False)()
+        return bool(is_tty)
+
+
+_BUILTIN_SKINS = (
+    Skin(
+        name="classic",
+        display_name="TamaOS Classic",
+        description="Balanced lattice frame inspired by the original bootstrap banner.",
+        top_left="╔",
+        top_right="╗",
+        bottom_left="╚",
+        bottom_right="╝",
+        horizontal="═",
+        vertical="║",
+        padding=2,
+        title_lines=(
+            "   ╔{bar}╗",
+            "   ║{name:^{width}}║",
+            "   ╚{bar}╝",
+        ),
+        animation_frames=("◇◇◇◇◇", "◆◇◆◇◆", "◇◆◇◆◇"),
+    ),
+    Skin(
+        name="synthwave",
+        display_name="Synthwave Bloom",
+        description="Prismatic slashes and neon accents for an eccentric boot ritual.",
+        top_left="╭",
+        top_right="╮",
+        bottom_left="╰",
+        bottom_right="╯",
+        horizontal="╼",
+        vertical="┃",
+        padding=3,
+        title_lines=(
+            "  ╭✶{bar}✶╮",
+            "  │{name:^{width}}│",
+            "  ╰✶{bar}✶╯",
+        ),
+        animation_frames=("⌁⌁✦⌁⌁", "✦⌁⌁✦⌁", "⌁✦⌁⌁✦"),
+    ),
+    Skin(
+        name="aurora",
+        display_name="Aurora Cascade",
+        description="Curved edges with cascading sparkles for a cosmic greeting.",
+        top_left="╭",
+        top_right="╮",
+        bottom_left="╰",
+        bottom_right="╯",
+        horizontal="─",
+        vertical="│",
+        padding=4,
+        title_lines=(
+            "    ✺{bar}✺",
+            "    ✶ {name:^{width}} ✶",
+            "    ✺{bar}✺",
+        ),
+        animation_frames=("· · · ✺", " · · ✺ ·", "  · ✺ · ·", "   ✺ · · ·"),
+    ),
+)
+
+
+__all__ = ["Skin", "SkinManager", "DEFAULT_SKIN_NAME"]


### PR DESCRIPTION
## Summary
- add a skin manager with built-in banner styles and animations
- update the REPL to render the banner with the active skin and provide `skin` commands
- document the new environment variables and usage instructions for styling the shell

## Testing
- python -m compileall tamaos

------
https://chatgpt.com/codex/tasks/task_e_68d1bdcf4894832fba1ddb05e1ec3630